### PR TITLE
Added User-Agent: DAVKit/4.0.1 to headers in icloud.php

### DIFF
--- a/PHP/icloud.php
+++ b/PHP/icloud.php
@@ -66,7 +66,7 @@
 		//Init cURL
 		$c=curl_init($url);
 		//Set headers
-		curl_setopt($c, CURLOPT_HTTPHEADER, array("Depth: 1", "Content-Type: text/xml; charset='UTF-8'"));
+		curl_setopt($c, CURLOPT_HTTPHEADER, array("Depth: 1", "Content-Type: text/xml; charset='UTF-8'", "User-Agent: DAVKit/4.0.1 (730); CalendarStore/4.0.1 (973); iCal/4.0.1 (1374); Mac OS X/10.6.2 (10C540)"));
 		curl_setopt($c, CURLOPT_HEADER, 0);
 		//Set SSL
 		curl_setopt($c, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
It seems to reject requests without the user-agent information being there. Adding a iCal DAVKit header fixes the issue.
